### PR TITLE
Generalize python executable location

### DIFF
--- a/bin/elf_diff
+++ b/bin/elf_diff
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
   
 # -*- coding: utf-8 -*-
 


### PR DESCRIPTION
Since /usr/bin/python isn't necessarily the path to the user's desired version of Python (e.g. using Python v3 on macOS), it's generally better to get it indirectly via /usr/bin/env.

I had some trouble getting this working until I figured out that it was running /usr/bin/python, which is not the version that I use on my iMac (/usr/bin/python is the one provided by Apple; the version installed by Homebrew, which comes first in `$PATH`, is elsewhere.